### PR TITLE
Add support for custom theme via url.

### DIFF
--- a/src/components/App/Trade/Trade.tsx
+++ b/src/components/App/Trade/Trade.tsx
@@ -55,7 +55,7 @@ const DirectionTab = styled.div<{
   height: 35px;
   line-height: 35px;
   text-align: center;
-  color: ${({ theme }) => theme.text1};
+  color: ${({ theme }) => theme.black};
   border-radius: ${({ isLong }) => (isLong ? '10px 0 0 10px' : '0 10px 10px 0')};
   ${({ theme, isLong, isShort, active }) =>
     isLong && active

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -10,6 +10,7 @@ import { useDarkModeManager } from 'state/user/hooks'
 import { Sidebar } from './Sidebar'
 import NavLogo from './NavLogo'
 import { Z_INDEX } from 'theme'
+import { useRouter } from 'next/router'
 
 const Wrapper = styled.div`
   display: flex;
@@ -52,6 +53,11 @@ export default function NavBar() {
   const [, toggleDarkMode] = useDarkModeManager()
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false)
 
+  // get custom theme name from url, if any
+  // allow the default light/dark theme toggle if there isn't any custom theme defined via url
+  const router = useRouter()
+  const showThemeToggle = !router.query?.theme
+
   const toggleSidebar = (isOpen: boolean) => {
     setSidebarOpen((prev) => isOpen ?? !prev)
   }
@@ -60,9 +66,11 @@ export default function NavBar() {
     <Wrapper>
       <NavLogo />
       <NavItems>
-        <NavButton onClick={() => toggleDarkMode()}>
-          <ThemeToggle size={20} />
-        </NavButton>
+        {showThemeToggle && (
+          <NavButton onClick={() => toggleDarkMode()}>
+            <ThemeToggle size={20} />
+          </NavButton>
+        )}
         <Web3Status />
         <Web3Network />
       </NavItems>

--- a/src/state/trade/hooks.ts
+++ b/src/state/trade/hooks.ts
@@ -7,6 +7,7 @@ import { useCurrency } from 'hooks/useCurrency'
 import { Collateral } from 'constants/addresses'
 import { useConductedContracts } from 'state/conducted/hooks'
 import { isAddress } from 'utils/validate'
+import { ParsedUrlQueryInput } from 'querystring'
 
 export default function useDefaultsFromURL(): {
   currencies: {
@@ -20,6 +21,7 @@ export default function useDefaultsFromURL(): {
   const router = useRouter()
 
   const contract = router.query?.contract?.length ? router.query.contract[0] : ''
+  const theme = router.query?.theme || undefined
   const baseCurrency = useCurrency(contracts.includes(contract) ? contract : undefined) || undefined
   const quoteCurrency = useCurrency((chainId && Collateral[chainId]) ?? Collateral[1]) || undefined
 
@@ -30,18 +32,24 @@ export default function useDefaultsFromURL(): {
   const setURLCurrency = useCallback(
     async (currencyOrContract: Currency | string) => {
       if (typeof currencyOrContract === 'string' && isAddress(currencyOrContract)) {
+        const query: ParsedUrlQueryInput = { contract: currencyOrContract }
+        // if there is a custom theme defined via url, preserve it
+        if (theme) {
+          query.theme = theme
+        }
         await router.push({
           pathname: router.pathname,
-          query: {
-            contract: currencyOrContract,
-          },
+          query,
         })
       } else if (instanceOfCurrency(currencyOrContract) && currencyOrContract?.wrapped?.address) {
+        const query: ParsedUrlQueryInput = { contract: currencyOrContract.wrapped.address }
+        // if there is a custom theme defined via url, preserve it
+        if (theme) {
+          query.theme = theme
+        }
         await router.push({
           pathname: router.pathname,
-          query: {
-            contract: currencyOrContract.wrapped.address,
-          },
+          query,
         })
       }
     },

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -9,6 +9,7 @@ import styled, {
 
 import { useIsDarkMode } from 'state/user/hooks'
 import { Colors } from './styled'
+import { useRouter } from 'next/router'
 
 type TextProps = Omit<TextPropsOriginal, 'css'>
 
@@ -47,69 +48,202 @@ const mediaWidthTemplates: { [width in keyof typeof MEDIA_WIDTHS]: typeof css } 
 const white = '#FFFFFF'
 const black = '#000000'
 
-function colors(darkMode: boolean): Colors {
-  return {
-    darkMode,
-    // base
-    white,
-    black,
+function colors(themeName: string): Colors {
+  const supportedThemes = ['light', 'dark', 'spiritswap']
+  // define colour scheme for each supported theme
+  const themeColors = {
+    light: {
+      themeName,
+      // base
+      white,
+      black,
 
-    // text
-    text1: darkMode ? '#FFFFFF' : '#000000',
-    text2: darkMode ? '#C3C5CB' : '#78787B',
-    text3: darkMode ? '#8F96AC' : '#808086',
-    text4: darkMode ? '#B2B9D2' : '#B8B8BE',
+      // text
+      text1: '#000000',
+      text2: '#78787B',
+      text3: '#808086',
+      text4: '#B8B8BE',
 
-    // backgrounds / greys
-    bg0: darkMode ? '#14181E' : '#FFFFFF',
-    bg1: darkMode ? '#262B35' : '#F5F6FC',
-    bg2: darkMode ? '#0F1217' : '#F0F0F7',
-    bg3: darkMode ? '#262B35' : '#E9E9F3',
+      // backgrounds / greys
+      bg0: '#FFFFFF',
+      bg1: '#F5F6FC',
+      bg2: '#F0F0F7',
+      bg3: '#E9E9F3',
 
-    // borders
-    border1: '#B8B8BE',
-    border2: 'rgba(99, 126, 161, 0.2)',
+      // borders
+      border1: '#B8B8BE',
+      border2: 'rgba(99, 126, 161, 0.2)',
 
-    //specialty colors
-    specialBG1: darkMode
-      ? '#0F1217'
-      : 'radial-gradient(95.21% 95.21% at 50% 4.79%, rgba(138, 148, 220, 0.2) 0%, rgba(255, 255, 255, 0.2) 100%)',
-    specialBG2: darkMode
-      ? '#14181E'
-      : 'linear-gradient(90deg, rgba(81, 171, 255, 0.1) 0%, rgba(22, 72, 250, 0.1) 100%), linear-gradient(0deg, #FFFFFF, #FFFFFF)',
+      //specialty colors
+      specialBG1:
+        'radial-gradient(95.21% 95.21% at 50% 4.79%, rgba(138, 148, 220, 0.2) 0%, rgba(255, 255, 255, 0.2) 100%)',
+      specialBG2:
+        'linear-gradient(90deg, rgba(81, 171, 255, 0.1) 0%, rgba(22, 72, 250, 0.1) 100%), linear-gradient(0deg, #FFFFFF, #FFFFFF)',
 
-    // primary colors
-    primary1: '#FFB463',
-    primary2: '#FFA76A',
-    primary3: 'linear-gradient(180deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 167, 106, 0) 100%), #FFA76A',
+      // primary colors
+      primary1: '#FFB463',
+      primary2: '#FFA76A',
+      primary3: 'linear-gradient(180deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 167, 106, 0) 100%), #FFA76A',
 
-    // color text
-    primaryText1: darkMode ? '#1749FA' : '#FFB463', // TODO check if we want these values
+      // color text
+      primaryText1: '#FFB463', // TODO check if we want these values
 
-    // secondary colors
-    secondary1: '#1749FA',
-    secondary2: 'rgba(23, 73, 250, 0.2)',
+      // secondary colors
+      secondary1: '#1749FA',
+      secondary2: 'rgba(23, 73, 250, 0.2)',
 
-    // other
-    red1: darkMode ? '#FF4343' : '#DA2D2B',
-    red2: darkMode ? '#F82D3A' : '#DF1F38',
-    red3: '#D60000',
-    green1: darkMode ? '#27AE60' : '#007D35',
-    yellow1: '#E3A507',
-    yellow2: '#FF8F00',
-    yellow3: '#F3B71E',
-    blue1: darkMode ? '#2172E5' : '#0068FC',
-    blue2: darkMode ? '#5199FF' : '#0068FC',
+      // other
+      red1: '#DA2D2B',
+      red2: '#DF1F38',
+      red3: '#D60000',
+      green1: '#007D35',
+      yellow1: '#E3A507',
+      yellow2: '#FF8F00',
+      yellow3: '#F3B71E',
+      blue1: '#0068FC',
+      blue2: '#0068FC',
 
-    error: darkMode ? '#FD4040' : '#DF1F38',
-    success: darkMode ? '#27AE60' : '#007D35',
-    warning: '#FF8F00',
+      error: '#DF1F38',
+      success: '#007D35',
+      warning: '#FF8F00',
+    },
+    dark: {
+      themeName,
+      // base
+      white,
+      black,
+
+      // text
+      text1: '#FFFFFF',
+      text2: '#C3C5CB',
+      text3: '#8F96AC',
+      text4: '#B2B9D2',
+
+      // backgrounds / greys
+      bg0: '#14181E',
+      bg1: '#262B35',
+      bg2: '#0F1217',
+      bg3: '#262B35',
+
+      // borders
+      border1: '#B8B8BE',
+      border2: 'rgba(99, 126, 161, 0.2)',
+
+      //specialty colors
+      specialBG1: '#0F1217',
+      specialBG2: '#14181E',
+
+      // primary colors
+      primary1: '#FFB463',
+      primary2: '#FFA76A',
+      primary3: 'linear-gradient(180deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 167, 106, 0) 100%), #FFA76A',
+
+      // color text
+      primaryText1: '#1749FA', // TODO check if we want these values
+
+      // secondary colors
+      secondary1: '#1749FA',
+      secondary2: 'rgba(23, 73, 250, 0.2)',
+
+      // other
+      red1: '#FF4343',
+      red2: '#F82D3A',
+      red3: '#D60000',
+      green1: '#27AE60',
+      yellow1: '#E3A507',
+      yellow2: '#FF8F00',
+      yellow3: '#F3B71E',
+      blue1: '#2172E5',
+      blue2: '#5199FF',
+
+      error: '#FD4040',
+      success: '#27AE60',
+      warning: '#FF8F00',
+    },
+    spiritswap: {
+      themeName,
+      // base
+      white,
+      black,
+
+      // text
+      text1: '#45BAE5',
+      text2: '#D9F1F9',
+      text3: '#C7EAF7',
+      text4: '#B4E3F4',
+
+      // backgrounds / greys
+      bg0: '#0D252D',
+      bg1: '#143744',
+      bg2: '#1B4A5B',
+      bg3: '#225D72',
+
+      // borders
+      border1: '#ECF8FC',
+      border2: 'rgba(99, 126, 161, 0.2)',
+
+      //specialty colors
+      specialBG1: '#061216',
+      specialBG2: '#061216',
+
+      // primary colors
+      primary1: '#71D887',
+      primary2: '#5AAC6C',
+      primary3: 'linear-gradient(180deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 167, 106, 0) 100%), #5AAC6C',
+
+      // color text
+      primaryText1: '#1749FA', // TODO check if we want these values
+
+      // secondary colors
+      secondary1: '#1749FA',
+      secondary2: 'rgba(23, 73, 250, 0.2)',
+
+      // other
+      red1: '#FF4343',
+      red2: '#F82D3A',
+      red3: '#D60000',
+      green1: '#27AE60',
+      yellow1: '#E3A507',
+      yellow2: '#FF8F00',
+      yellow3: '#F3B71E',
+      blue1: '#2172E5',
+      blue2: '#5199FF',
+
+      error: '#FD4040',
+      success: '#27AE60',
+      warning: '#FF8F00',
+    },
   }
+  // default the theme to light mode
+  return supportedThemes.includes(themeName) ? themeColors[themeName] : themeColors['light']
 }
 
-function theme(darkMode: boolean): DefaultTheme {
+function shadows(themeName: string): Shadows {
+  const supportedThemes = ['light', 'dark', 'spiritswap']
+  // define shadow scheme for each supported theme
+  const themeShadows = {
+    light: {
+      shadow1: '#2F80ED',
+      boxShadow1: '0px 0px 4px rgba(0, 0, 0, 0.125)',
+      boxShadow2: '0px 5px 5px rgba(0, 0, 0, 0.15)',
+    },
+    dark: {
+      shadow1: '#000',
+      boxShadow1: '0px 0px 4px rgba(0, 0, 0, 0.125)',
+      boxShadow2: '0px 5px 5px rgba(0, 0, 0, 0.15)',
+    },
+    spiritswap: {
+      shadow1: '#000',
+      boxShadow1: '0px 0px 4px rgba(0, 0, 0, 0.125)',
+      boxShadow2: '0px 5px 5px rgba(0, 0, 0, 0.15)',
+    },
+  }
+  return themeName in supportedThemes ? themeShadows[themeName] : themeShadows['light']
+}
+
+function theme(themeName: string): DefaultTheme {
   return {
-    ...colors(darkMode),
+    ...colors(themeName),
 
     grids: {
       sm: 8,
@@ -118,9 +252,7 @@ function theme(darkMode: boolean): DefaultTheme {
     },
 
     //shadows
-    shadow1: darkMode ? '#000' : '#2F80ED',
-    boxShadow1: '0px 0px 4px rgba(0, 0, 0, 0.125)',
-    boxShadow2: '0px 5px 5px rgba(0, 0, 0, 0.15)',
+    ...shadows(themeName),
 
     // media queries
     mediaWidth: mediaWidthTemplates,
@@ -128,8 +260,14 @@ function theme(darkMode: boolean): DefaultTheme {
 }
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  // get theme name from url if any
+  const router = useRouter()
+  let themeName = router.query?.theme
+  
   const darkMode = useIsDarkMode()
-  const themeObject = useMemo(() => theme(darkMode), [darkMode])
+  // if url doesn't have theme name, then use standard light/dark themes
+  if (!themeName) themeName = darkMode ? 'dark' : 'light'
+  const themeObject = useMemo(() => theme(themeName), [themeName])
 
   return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
 }

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -8,8 +8,9 @@ import styled, {
 } from 'styled-components'
 
 import { useIsDarkMode } from 'state/user/hooks'
-import { Colors } from './styled'
+import { Colors, Shadows } from './styled'
 import { useRouter } from 'next/router'
+import { SupportedChainId } from 'constants/chains'
 
 type TextProps = Omit<TextPropsOriginal, 'css'>
 
@@ -48,12 +49,19 @@ const mediaWidthTemplates: { [width in keyof typeof MEDIA_WIDTHS]: typeof css } 
 const white = '#FFFFFF'
 const black = '#000000'
 
-function colors(themeName: string): Colors {
-  const supportedThemes = ['light', 'dark', 'spiritswap']
+export enum SupportedThemes {
+  LIGHT = 'light',
+  DARK = 'dark',
+  SPIRIT = 'spirit',
+  SPIRIT2 = 'spirit2',
+}
+
+function colors(themeName: SupportedThemes): Colors {
   // define colour scheme for each supported theme
   const themeColors = {
-    light: {
-      themeName,
+    [SupportedThemes.LIGHT]: {
+      themeName: SupportedThemes.LIGHT,
+
       // base
       white,
       black,
@@ -107,8 +115,9 @@ function colors(themeName: string): Colors {
       success: '#007D35',
       warning: '#FF8F00',
     },
-    dark: {
-      themeName,
+    [SupportedThemes.DARK]: {
+      themeName: SupportedThemes.DARK,
+
       // base
       white,
       black,
@@ -160,8 +169,9 @@ function colors(themeName: string): Colors {
       success: '#27AE60',
       warning: '#FF8F00',
     },
-    spiritswap: {
-      themeName,
+    [SupportedThemes.SPIRIT]: {
+      themeName: SupportedThemes.SPIRIT,
+
       // base
       white,
       black,
@@ -183,8 +193,66 @@ function colors(themeName: string): Colors {
       border2: 'rgba(99, 126, 161, 0.2)',
 
       //specialty colors
-      specialBG1: '#061216',
-      specialBG2: '#061216',
+      specialBG1: '#1B4A5B',
+      specialBG2: '#1B4A5B',
+
+      // primary colors
+      primary1: '#71D887',
+      primary2: '#5AAC6C',
+      primary3: 'linear-gradient(180deg, rgba(255, 255, 255, 0.5) 0%, rgba(255, 167, 106, 0) 100%), #5AAC6C',
+
+      // color text
+      primaryText1: '#1749FA', // TODO check if we want these values
+
+      // secondary colors
+      secondary1: '#1749FA',
+      secondary2: 'rgba(23, 73, 250, 0.2)',
+
+      // other
+      red1: '#FF4343',
+      red2: '#F82D3A',
+      red3: '#D60000',
+      green1: '#27AE60',
+      yellow1: '#E3A507',
+      yellow2: '#FF8F00',
+      yellow3: '#F3B71E',
+      blue1: '#2172E5',
+      blue2: '#5199FF',
+
+      error: '#FD4040',
+      success: '#27AE60',
+      warning: '#FF8F00',
+    },
+    [SupportedThemes.SPIRIT2]: {
+      themeName: SupportedThemes.SPIRIT2,
+
+      // base
+      white,
+      black,
+
+      // text
+      text1: '#45BAE5',
+      text2: '#D9F1F9',
+      text3: '#C7EAF7',
+      text4: '#B4E3F4',
+
+      // backgrounds / greys
+      bg0: 'rgb(13, 15, 34)',
+      bg1: 'rgba(96, 213, 220, 0.25)',
+      bg2: 'rgb(21, 30, 49)',
+      bg3: 'rgba(96, 213, 220, 0.05)',
+
+      // borders
+      border1: '#ECF8FC',
+      border2: 'rgba(99, 126, 161, 0.2)',
+
+      //long short btn colours
+      long: '#71D887',
+      short: '#45BAE5',
+
+      //specialty colors
+      specialBG1: 'rgb(13, 15, 34)',
+      specialBG2: 'rgb(21, 30, 49)',
 
       // primary colors
       primary1: '#71D887',
@@ -215,33 +283,38 @@ function colors(themeName: string): Colors {
     },
   }
   // default the theme to light mode
-  return supportedThemes.includes(themeName) ? themeColors[themeName] : themeColors['light']
+  return themeName in SupportedThemes ? themeColors[SupportedThemes.LIGHT] : themeColors[themeName]
 }
 
-function shadows(themeName: string): Shadows {
-  const supportedThemes = ['light', 'dark', 'spiritswap']
-  // define shadow scheme for each supported theme
+// define shadow scheme for each supported theme
+function shadows(themeName: SupportedThemes): Shadows {
   const themeShadows = {
-    light: {
+    [SupportedThemes.LIGHT]: {
       shadow1: '#2F80ED',
       boxShadow1: '0px 0px 4px rgba(0, 0, 0, 0.125)',
       boxShadow2: '0px 5px 5px rgba(0, 0, 0, 0.15)',
     },
-    dark: {
+    [SupportedThemes.DARK]: {
       shadow1: '#000',
       boxShadow1: '0px 0px 4px rgba(0, 0, 0, 0.125)',
       boxShadow2: '0px 5px 5px rgba(0, 0, 0, 0.15)',
     },
-    spiritswap: {
+    [SupportedThemes.SPIRIT]: {
       shadow1: '#000',
       boxShadow1: '0px 0px 4px rgba(0, 0, 0, 0.125)',
-      boxShadow2: '0px 5px 5px rgba(0, 0, 0, 0.15)',
+      boxShadow2: 'rgb(96 213 220) 0px 4px 30px',
+    },
+    [SupportedThemes.SPIRIT2]: {
+      shadow1: '#000',
+      boxShadow1: '0px 0px 4px rgba(0, 0, 0, 0.125)',
+      boxShadow2: 'rgb(96 213 220) 0px 4px 30px',
     },
   }
-  return themeName in supportedThemes ? themeShadows[themeName] : themeShadows['light']
+  // default the theme to light mode
+  return themeName in SupportedThemes ? themeShadows[SupportedThemes.LIGHT] : themeShadows[themeName]
 }
 
-function theme(themeName: string): DefaultTheme {
+function theme(themeName: SupportedThemes): DefaultTheme {
   return {
     ...colors(themeName),
 
@@ -262,11 +335,18 @@ function theme(themeName: string): DefaultTheme {
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
   // get theme name from url if any
   const router = useRouter()
-  let themeName = router.query?.theme
-  
+  const parsed = router.query?.theme
+  let parsedTheme = parsed && typeof parsed === 'string' ? parsed : undefined
+
   const darkMode = useIsDarkMode()
-  // if url doesn't have theme name, then use standard light/dark themes
-  if (!themeName) themeName = darkMode ? 'dark' : 'light'
+
+  let themeName: SupportedThemes
+  if (parsedTheme && Object.values(SupportedThemes).some((theme: string) => theme === parsedTheme)) {
+    themeName = parsedTheme as SupportedThemes
+  } else {
+    themeName = darkMode ? SupportedThemes.DARK : SupportedThemes.LIGHT
+  }
+
   const themeObject = useMemo(() => theme(themeName), [themeName])
 
   return <StyledComponentsThemeProvider theme={themeObject}>{children}</StyledComponentsThemeProvider>
@@ -349,7 +429,7 @@ export const ThemedGlobalStyle = createGlobalStyle`
 
   body {
     font-family: 'Rubik';
-    background: ${({ theme }) => theme.specialBG1}
+    background: ${({ theme }) => theme.specialBG1};
   }
 
   button {

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -2,7 +2,7 @@ import { ThemedCssFunction } from 'styled-components/macro'
 
 export type Color = string
 export interface Colors {
-  darkMode: boolean
+  themeName: string
 
   // base
   white: Color
@@ -52,6 +52,13 @@ export interface Colors {
   error: Color
   success: Color
   warning: Color
+}
+
+export type Shadow = string
+export interface Shadows {
+  shadow1: Shadow
+  boxShadow2: Shadow
+  boxShadow2: Shadow
 }
 
 declare module 'styled-components' {

--- a/src/theme/styled.d.ts
+++ b/src/theme/styled.d.ts
@@ -1,8 +1,9 @@
 import { ThemedCssFunction } from 'styled-components/macro'
+import { SupportedThemes } from 'theme'
 
 export type Color = string
 export interface Colors {
-  themeName: string
+  themeName: SupportedThemes
 
   // base
   white: Color
@@ -57,18 +58,13 @@ export interface Colors {
 export type Shadow = string
 export interface Shadows {
   shadow1: Shadow
-  boxShadow2: Shadow
+  boxShadow1: Shadow
   boxShadow2: Shadow
 }
 
 declare module 'styled-components' {
-  export interface DefaultTheme extends Colors {
+  export interface DefaultTheme extends Colors, Shadows {
     grids: Grids
-
-    // shadows
-    shadow1: string
-    boxShadow1: string
-    boxShadow2: string
 
     // media queries
     mediaWidth: {


### PR DESCRIPTION
Supports custom themes via url.

- spiritswap theme is supported by adding `?theme=spiritswap` to the url.

- a trailing suffix of `?theme=themeName` displays the app in respective theme if it is defined.

- when a custom theme is defined via url, the light/dark theme toggle is disabled.